### PR TITLE
Add kubernetes SBOM tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ From [Wikipedia](https://en.wikipedia.org/wiki/Software_bill_of_materials):
 - [dlorenc/sbom-oci](https://github.com/dlorenc/sbom-oci)
 - [Cosign SBOM Spec](https://github.com/sigstore/cosign/blob/main/specs/SBOM_SPEC.md)
 - [SwiftBOM - generate SBOMs](https://github.com/CERTCC/SBOM/tree/master/SwiftBOM)
+- [Kubernetes SBOM Tool](https://sigs.k8s.io/bom)
 
 ## SPDX
 


### PR DESCRIPTION
This PR adds to the readme a link to the Kubernetes `bom` tool.
This tool allows any golang project to generate a SPDX bill of materials
as well as leverage the libraries to add SBOM generating capabilities to
any Go project.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@chainguard.dev>