### PR TITLE
Adds bomber to the list of community repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ From [Wikipedia](https://en.wikipedia.org/wiki/Software_bill_of_materials):
 
 - [SBOM-Operator for Kubernetes](https://github.com/ckotzbauer/sbom-operator)
 
+### Security Tools
+
+- [bomber](https://github.com/devops-kung-fu/bomber) - bomber is an application that scans SBoMs for security vulnerabilities.
+
 ## Articles and Blogs
 
 - [Software Bill Of Materials: Formats, Use Cases, and Tools](https://fossa.com/blog/software-bill-of-materials-formats-use-cases-tools/)


### PR DESCRIPTION
```bomber``` is an application that scans SBOMs for security vulnerabilities. Given an SBOM in CycloneDX, SPDX, or Syft format, it connects to either OSV.dev or OSS Index to determine if any packages in the SBOM have vulnerabilities.

How is this different from tools like Grype, etc? It's all in the ecosytems supported. Where most SBOM scanners only handle deb and rpm (containers), ```bomber``` handles *code* ecosystems like PyPI, rpm, gem, Cocoapods, etc.

Check out https://github.com/devops-kung-fu/bomber for more information.