### PR TITLE
Added SBOM viewer from Rancher Application Collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ From [Wikipedia](https://en.wikipedia.org/wiki/Software_bill_of_materials):
 |[Syft](https://github.com/anchore/syft)|CycloneDX,SPDX|CycloneDX,SPDX| |CycloneDX,SPDX|
 |Snyk SBOM [API](https://docs.snyk.io/snyk-api-info) & [CLI](https://docs.snyk.io/snyk-cli)|CycloneDX,SPDX|
 |[Snyk SBOM Checker](https://snyk.io/code-checker/sbom-security/)| |CycloneDX,SPDX|
+|[SBOM viewer](https://apps.rancher.io/sbom-viewer)| | | | CycloneDX,SPDX|
 |[SPDX Maven Plugin](https://github.com/spdx/spdx-maven-plugin)|SPDX|
 |[SPDX Gradle Plugin](https://github.com/spdx/spdx-gradle-plugin)|SPDX|
 |[spdx-sbom-generator](https://github.com/spdx/spdx-sbom-generator)|SPDX|


### PR DESCRIPTION
[SBOM viewer](https://apps.rancher.io/sbom-viewer) is an online viewer of software bill of materials attestation in a human-friendly manner.

It is still in an early stage. This tool is developed by [SUSE](https://www.suse.com/).