### PR TITLE
Add Meta Package Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ From [Wikipedia](https://en.wikipedia.org/wiki/Software_bill_of_materials):
 |[Tern](https://github.com/tern-tools/tern)|CycloneDX,SPDX|
 |[Trivy](https://github.com/aquasecurity/trivy)|CycloneDX,SPDX|CycloneDX,SPDX| |CycloneDX,SPDX|
 |[DeepSCA](https://tools.deepbits.com)|CycloneDX|CycloneDX||CyclondeDX||CyclondeDX|||CyclondeDX|
+|[Meta Package Manager](https://github.com/kdeldycke/meta-package-manager#readme)|CycloneDX,SPDX|||||||||
 
 ### Repositories
 


### PR DESCRIPTION
Meta Package Manager is a multi-platform CLI which allows you to export a SBOM of all packages installed on a system: https://kdeldycke.github.io/meta-package-manager/usecase.html#sbom-software-bill-of-materials